### PR TITLE
first pass at adding in AVURLAsset downloading

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897FF4019AA800700AB5182 /* Alamofire.swift */; };
 		6452770D1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6452770C1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift */; };
 		8035DB621BAB492500466CB3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */; };
+		BAD00F071DF068CB0025FDBE /* AVAssetDownloadResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD00F061DF068CB0025FDBE /* AVAssetDownloadResponse.swift */; };
 		E4202FD01B667AA100C997FB /* ParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */; };
 		E4202FD11B667AA100C997FB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C391AF899EC00BABAE5 /* Request.swift */; };
 		E4202FD21B667AA100C997FB /* ResponseSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C451AF89FF300BABAE5 /* ResponseSerialization.swift */; };
@@ -357,6 +358,7 @@
 		B39E2F871C1A72F8002DA1A9 /* certPEM.crt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = certPEM.crt; path = selfSignedAndMalformedCerts/certPEM.crt; sourceTree = "<group>"; };
 		B39E2F891C1A72F8002DA1A9 /* randomGibberish.crt */ = {isa = PBXFileReference; lastKnownFileType = file; name = randomGibberish.crt; path = selfSignedAndMalformedCerts/randomGibberish.crt; sourceTree = "<group>"; };
 		B39E2F8A1C1A72F8002DA1A9 /* keyDER.der */ = {isa = PBXFileReference; lastKnownFileType = file; name = keyDER.der; path = selfSignedAndMalformedCerts/keyDER.der; sourceTree = "<group>"; };
+		BAD00F061DF068CB0025FDBE /* AVAssetDownloadResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVAssetDownloadResponse.swift; sourceTree = "<group>"; };
 		E4202FE01B667AA100C997FB /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3319A95C8B0040E7D1 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3719A95C8B0040E7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -588,6 +590,7 @@
 				4C1DC8531B68908E00476DE3 /* AFError.swift */,
 				6452770C1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift */,
 				4CB928281C66BFBC00CE5F08 /* Notifications.swift */,
+				BAD00F061DF068CB0025FDBE /* AVAssetDownloadResponse.swift */,
 				4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */,
 				4CDE2C391AF899EC00BABAE5 /* Request.swift */,
 				4C0B62501BB1001C009302D3 /* Response.swift */,
@@ -1250,6 +1253,7 @@
 				4CDE2C3A1AF899EC00BABAE5 /* Request.swift in Sources */,
 				6452770D1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift in Sources */,
 				4CDE2C461AF89FF300BABAE5 /* ResponseSerialization.swift in Sources */,
+				BAD00F071DF068CB0025FDBE /* AVAssetDownloadResponse.swift in Sources */,
 				4C1DC8541B68908E00476DE3 /* AFError.swift in Sources */,
 				4CDE2C371AF8932A00BABAE5 /* SessionManager.swift in Sources */,
 				4C0B62511BB1001C009302D3 /* Response.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		4CFCFE3C1D56E8D900A76388 /* TaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFCFE381D56E8D900A76388 /* TaskDelegate.swift */; };
 		4DD67C241A5C58FB00ED2280 /* Alamofire.h in Headers */ = {isa = PBXBuildFile; fileRef = F8111E3819A95C8B0040E7D1 /* Alamofire.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897FF4019AA800700AB5182 /* Alamofire.swift */; };
+		6452770D1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6452770C1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift */; };
 		8035DB621BAB492500466CB3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */; };
 		E4202FD01B667AA100C997FB /* ParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */; };
 		E4202FD11B667AA100C997FB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C391AF899EC00BABAE5 /* Request.swift */; };
@@ -347,6 +348,7 @@
 		4CFCFE2D1D56D31700A76388 /* SessionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDelegate.swift; sourceTree = "<group>"; };
 		4CFCFE381D56E8D900A76388 /* TaskDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskDelegate.swift; sourceTree = "<group>"; };
 		4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6452770C1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AVDownloadSessionDelegate.swift; path = Source/AVDownloadSessionDelegate.swift; sourceTree = SOURCE_ROOT; };
 		72998D721BF26173006D3F69 /* Info-tvOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		B39E2F831C1A72F8002DA1A9 /* certDER.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.cer; path = selfSignedAndMalformedCerts/certDER.cer; sourceTree = "<group>"; };
 		B39E2F841C1A72F8002DA1A9 /* certDER.crt */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.crt; path = selfSignedAndMalformedCerts/certDER.crt; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 			isa = PBXGroup;
 			children = (
 				4C1DC8531B68908E00476DE3 /* AFError.swift */,
+				6452770C1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift */,
 				4CB928281C66BFBC00CE5F08 /* Notifications.swift */,
 				4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */,
 				4CDE2C391AF899EC00BABAE5 /* Request.swift */,
@@ -1245,6 +1248,7 @@
 				4CFCFE2E1D56D31700A76388 /* SessionDelegate.swift in Sources */,
 				4CE2724F1AF88FB500F1D59A /* ParameterEncoding.swift in Sources */,
 				4CDE2C3A1AF899EC00BABAE5 /* Request.swift in Sources */,
+				6452770D1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift in Sources */,
 				4CDE2C461AF89FF300BABAE5 /* ResponseSerialization.swift in Sources */,
 				4C1DC8541B68908E00476DE3 /* AFError.swift in Sources */,
 				4CDE2C371AF8932A00BABAE5 /* SessionManager.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		6452770D1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6452770C1DEA85FF00E582CE /* AVDownloadSessionDelegate.swift */; };
 		8035DB621BAB492500466CB3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */; };
 		BAD00F071DF068CB0025FDBE /* AVAssetDownloadResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD00F061DF068CB0025FDBE /* AVAssetDownloadResponse.swift */; };
+		BAD00F2B1DF1C3950025FDBE /* AVAssetDownloadsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD00F2A1DF1C3950025FDBE /* AVAssetDownloadsTest.swift */; };
 		E4202FD01B667AA100C997FB /* ParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */; };
 		E4202FD11B667AA100C997FB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C391AF899EC00BABAE5 /* Request.swift */; };
 		E4202FD21B667AA100C997FB /* ResponseSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C451AF89FF300BABAE5 /* ResponseSerialization.swift */; };
@@ -359,6 +360,7 @@
 		B39E2F891C1A72F8002DA1A9 /* randomGibberish.crt */ = {isa = PBXFileReference; lastKnownFileType = file; name = randomGibberish.crt; path = selfSignedAndMalformedCerts/randomGibberish.crt; sourceTree = "<group>"; };
 		B39E2F8A1C1A72F8002DA1A9 /* keyDER.der */ = {isa = PBXFileReference; lastKnownFileType = file; name = keyDER.der; path = selfSignedAndMalformedCerts/keyDER.der; sourceTree = "<group>"; };
 		BAD00F061DF068CB0025FDBE /* AVAssetDownloadResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVAssetDownloadResponse.swift; sourceTree = "<group>"; };
+		BAD00F2A1DF1C3950025FDBE /* AVAssetDownloadsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVAssetDownloadsTest.swift; sourceTree = "<group>"; };
 		E4202FE01B667AA100C997FB /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3319A95C8B0040E7D1 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3719A95C8B0040E7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 				F8111E5B19A9674D0040E7D1 /* DownloadTests.swift */,
 				F8111E5C19A9674D0040E7D1 /* ParameterEncodingTests.swift */,
 				F8111E5D19A9674D0040E7D1 /* RequestTests.swift */,
+				BAD00F2A1DF1C3950025FDBE /* AVAssetDownloadsTest.swift */,
 				F8111E5E19A9674D0040E7D1 /* ResponseTests.swift */,
 				4CA028C41B7466C500C84163 /* ResultTests.swift */,
 				4C9DCE771CB1BCE2003E6463 /* SessionDelegateTests.swift */,
@@ -1292,6 +1295,7 @@
 				F8AE910219D28DCC0078C7B2 /* ValidationTests.swift in Sources */,
 				F8111E6119A9674D0040E7D1 /* ParameterEncodingTests.swift in Sources */,
 				F8111E6419A9674D0040E7D1 /* UploadTests.swift in Sources */,
+				BAD00F2B1DF1C3950025FDBE /* AVAssetDownloadsTest.swift in Sources */,
 				4C3D00581C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift in Sources */,
 				F8111E6019A9674D0040E7D1 /* DownloadTests.swift in Sources */,
 			);

--- a/Source/AVAssetDownloadResponse.swift
+++ b/Source/AVAssetDownloadResponse.swift
@@ -10,9 +10,13 @@ import UIKit
 import AVFoundation
 
 /// Used to store all data associated with a response of a avAssetDownload request.
+@available(iOSApplicationExtension 9.0, *)
 public struct AVAssetDownloadResponse {
     /// The AVURLAsset that we began with.
     public let avURLAsset: AVURLAsset?
+    
+    /// The resolved media selection
+    public let resolvedMediaSelection: AVMediaSelection?
     
     /// The server's response to the URL request.
     public let response: HTTPURLResponse?
@@ -25,8 +29,9 @@ public struct AVAssetDownloadResponse {
     
     var _metrics: AnyObject?
     
-    init(avURLAsset: AVURLAsset?, response: HTTPURLResponse?, error: Error?, timeline: Timeline = Timeline()) {
+    init(avURLAsset: AVURLAsset?, resolvedMediaSelection: AVMediaSelection?, response: HTTPURLResponse?, error: Error?, timeline: Timeline = Timeline()) {
         self.avURLAsset = avURLAsset
+        self.resolvedMediaSelection = resolvedMediaSelection
         self.response = response
         self.error = error
         self.timeline = timeline
@@ -35,6 +40,7 @@ public struct AVAssetDownloadResponse {
 }
 // MARK: -
 
+@available(iOSApplicationExtension 9.0, *)
 extension AVAssetDownloadResponse: CustomStringConvertible, CustomDebugStringConvertible {
     /// The textual representation used when written to an output stream, which includes whether the result was a
     /// success or failure.
@@ -48,6 +54,7 @@ extension AVAssetDownloadResponse: CustomStringConvertible, CustomDebugStringCon
         var output: [String] = []
         
         output.append(avURLAsset != nil ? "[AVURLAsset]: \(avURLAsset!)" : "[AVURLAsset]: nil")
+        output.append(resolvedMediaSelection != nil ? "[AVMediaSelection]: \(resolvedMediaSelection!)" : "[AVMediaSelection]: nil")
         output.append(response != nil ? "[Response]: \(response!)" : "[Response]: nil")
         output.append("[Timeline]: \(timeline.debugDescription)")
         
@@ -78,6 +85,7 @@ extension AVAssetDownloadRequest {
             (queue ?? DispatchQueue.main).async {
                 var avAssetResponse = AVAssetDownloadResponse(
                     avURLAsset: self.avAsset,
+                    resolvedMediaSelection: self.avAssetDownloadDelegate.resolvedMediaSelection,
                     response: self.response,
                     error: self.delegate.error,
                     timeline: self.timeline

--- a/Source/AVAssetDownloadResponse.swift
+++ b/Source/AVAssetDownloadResponse.swift
@@ -1,0 +1,95 @@
+//
+//  AVAssetDownloadResponse.swift
+//  Alamofire
+//
+//  Created by Dan Morrow on 12/1/16.
+//  Copyright © 2016 Alamofire. All rights reserved.
+//
+
+import UIKit
+import AVFoundation
+
+/// Used to store all data associated with a response of a avAssetDownload request.
+public struct AVAssetDownloadResponse {
+    /// The AVURLAsset that we began with.
+    public let avURLAsset: AVURLAsset?
+    
+    /// The server's response to the URL request.
+    public let response: HTTPURLResponse?
+    
+    /// The error encountered while executing or validating the request.
+    public let error: Error?
+    
+    /// The timeline of the complete lifecycle of the request.
+    public let timeline: Timeline
+    
+    var _metrics: AnyObject?
+    
+    init(avURLAsset: AVURLAsset?, response: HTTPURLResponse?, error: Error?, timeline: Timeline = Timeline()) {
+        self.avURLAsset = avURLAsset
+        self.response = response
+        self.error = error
+        self.timeline = timeline
+    }
+
+}
+// MARK: -
+
+extension AVAssetDownloadResponse: CustomStringConvertible, CustomDebugStringConvertible {
+    /// The textual representation used when written to an output stream, which includes whether the result was a
+    /// success or failure.
+    public var description: String {
+        return avURLAsset.debugDescription
+    }
+    
+    /// The debug textual representation used when written to an output stream, which includes the URL request, the URL
+    /// response, the server data, the response serialization result and the timeline.
+    public var debugDescription: String {
+        var output: [String] = []
+        
+        output.append(avURLAsset != nil ? "[AVURLAsset]: \(avURLAsset!)" : "[AVURLAsset]: nil")
+        output.append(response != nil ? "[Response]: \(response!)" : "[Response]: nil")
+        output.append("[Timeline]: \(timeline.debugDescription)")
+        
+        return output.joined(separator: "\n")
+    }
+}
+
+@available(iOS 10.0, *)
+extension AVAssetDownloadResponse : Response {
+    #if !os(watchOS)
+    /// The task metrics containing the request / response statistics.
+    public var metrics: URLSessionTaskMetrics? { return _metrics as? URLSessionTaskMetrics }
+    #endif
+}
+
+
+@available(iOSApplicationExtension 9.0, *)
+extension AVAssetDownloadRequest {
+    /// Adds a handler to be called once the request has finished.
+    ///
+    /// - parameter queue:             The queue on which the completion handler is dispatched.
+    /// - parameter completionHandler: The code to be executed once the request has finished.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    public func response(queue: DispatchQueue? = nil, completionHandler: @escaping (AVAssetDownloadResponse) -> Void) -> Self {
+        delegate.queue.addOperation {
+            (queue ?? DispatchQueue.main).async {
+                var avAssetResponse = AVAssetDownloadResponse(
+                    avURLAsset: self.avAsset,
+                    response: self.response,
+                    error: self.delegate.error,
+                    timeline: self.timeline
+                )
+                
+                avAssetResponse.add(self.delegate.metrics)
+                
+                completionHandler(avAssetResponse)
+            }
+        }
+        
+        return self
+    }
+}
+

--- a/Source/AVDownloadSessionDelegate.swift
+++ b/Source/AVDownloadSessionDelegate.swift
@@ -9,7 +9,7 @@
 import AVFoundation
 
 @available(iOSApplicationExtension 9.0, *)
-class AVDownloadSessionDelegate: SessionDelegate {
+open class AVDownloadSessionDelegate: SessionDelegate {
 
     // MARK: AVAssetDownloadDelegate Overrides
     
@@ -27,7 +27,7 @@ class AVDownloadSessionDelegate: SessionDelegate {
 @available(iOSApplicationExtension 9.0, *)
 extension AVDownloadSessionDelegate : AVAssetDownloadDelegate {
     
-    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didFinishDownloadingTo location: URL) {
+    public func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didFinishDownloadingTo location: URL) {
         if let avSessionDownloadTaskDidFinishLoadingTo = avSessionDownloadTaskDidFinishLoadingTo {
             avSessionDownloadTaskDidFinishLoadingTo(session, assetDownloadTask, location)
         } else if let delegate = self[assetDownloadTask]?.delegate as? AVAssetDownloadTaskDelegate {
@@ -36,7 +36,7 @@ extension AVDownloadSessionDelegate : AVAssetDownloadDelegate {
 
     }
     
-    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didLoad timeRange: CMTimeRange, totalTimeRangesLoaded loadedTimeRanges: [NSValue], timeRangeExpectedToLoad: CMTimeRange) {
+    public func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didLoad timeRange: CMTimeRange, totalTimeRangesLoaded loadedTimeRanges: [NSValue], timeRangeExpectedToLoad: CMTimeRange) {
         if let avSessionDownloadDidLoadRanges = avSessionDownloadDidLoadRanges {
             avSessionDownloadDidLoadRanges(session, assetDownloadTask, timeRange, loadedTimeRanges, timeRangeExpectedToLoad)
         } else if let delegate = self[assetDownloadTask]?.delegate as? AVAssetDownloadTaskDelegate {
@@ -44,7 +44,7 @@ extension AVDownloadSessionDelegate : AVAssetDownloadDelegate {
         }
     }
     
-    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didResolve resolvedMediaSelection: AVMediaSelection) {
+    public func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didResolve resolvedMediaSelection: AVMediaSelection) {
         if let avSessionDownloadDidResolve = avSessionDownloadDidResolve {
             avSessionDownloadDidResolve(session, assetDownloadTask, resolvedMediaSelection)
         } else if let delegate = self[assetDownloadTask]?.delegate as? AVAssetDownloadTaskDelegate {

--- a/Source/AVDownloadSessionDelegate.swift
+++ b/Source/AVDownloadSessionDelegate.swift
@@ -1,0 +1,54 @@
+//
+//  AVDownloadSessionDelegate.swift
+//  Alamofire
+//
+//  Created by Daniel Morrow on 11/26/16.
+//  Copyright © 2016 Alamofire. All rights reserved.
+//
+
+import AVFoundation
+
+@available(iOSApplicationExtension 9.0, *)
+class AVDownloadSessionDelegate: SessionDelegate {
+
+    // MARK: AVAssetDownloadDelegate Overrides
+    
+    /// Overrides default behavior for AVAssetDownloadDelegate method `urlSession(_:assetDownloadTask:location:)`.
+    open var avSessionDownloadTaskDidFinishLoadingTo: ((URLSession, AVAssetDownloadTask, URL) -> Void)?
+    
+    /// Overrides default behavior for AVAssetDownloadDelegate method `urlSession(_:assetDownloadTask:didLoad:totalTimeRangesLoaded:timeRangeExpectedToLoad:)`.
+    open var avSessionDownloadDidLoadRanges: ((URLSession, AVAssetDownloadTask, CMTimeRange, [NSValue], CMTimeRange) -> Void)?
+    
+    /// Overrides default behavior for AVAssetDownloadDelegate method `urlSession(_:assetDownloadTask:didResolve:)`.
+    open var avSessionDownloadDidResolve: ((URLSession, AVAssetDownloadTask, AVMediaSelection) -> Void)?
+    
+}
+
+@available(iOSApplicationExtension 9.0, *)
+extension AVDownloadSessionDelegate : AVAssetDownloadDelegate {
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didFinishDownloadingTo location: URL) {
+        if let avSessionDownloadTaskDidFinishLoadingTo = avSessionDownloadTaskDidFinishLoadingTo {
+            avSessionDownloadTaskDidFinishLoadingTo(session, assetDownloadTask, location)
+        } else if let delegate = self[assetDownloadTask]?.delegate as? AVAssetDownloadTaskDelegate {
+            delegate.urlSession(session, assetDownloadTask: assetDownloadTask, didFinishDownloadingTo: location)
+        }
+
+    }
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didLoad timeRange: CMTimeRange, totalTimeRangesLoaded loadedTimeRanges: [NSValue], timeRangeExpectedToLoad: CMTimeRange) {
+        if let avSessionDownloadDidLoadRanges = avSessionDownloadDidLoadRanges {
+            avSessionDownloadDidLoadRanges(session, assetDownloadTask, timeRange, loadedTimeRanges, timeRangeExpectedToLoad)
+        } else if let delegate = self[assetDownloadTask]?.delegate as? AVAssetDownloadTaskDelegate {
+            delegate.urlSession(session, assetDownloadTask: assetDownloadTask, didLoad: timeRange, totalTimeRangesLoaded: loadedTimeRanges, timeRangeExpectedToLoad: timeRangeExpectedToLoad)
+        }
+    }
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didResolve resolvedMediaSelection: AVMediaSelection) {
+        if let avSessionDownloadDidResolve = avSessionDownloadDidResolve {
+            avSessionDownloadDidResolve(session, assetDownloadTask, resolvedMediaSelection)
+        } else if let delegate = self[assetDownloadTask]?.delegate as? AVAssetDownloadTaskDelegate {
+            delegate.urlSession(session, assetDownloadTask: assetDownloadTask, didResolve: resolvedMediaSelection)
+        }
+    }
+}

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -144,10 +144,10 @@ open class Request {
         case .avAssetDownload(let originalTask, let task):
             if #available(iOSApplicationExtension 9.0, *) {
                 taskDelegate = AVAssetDownloadTaskDelegate(avTask: task)
-                self.originalTask = originalTask
             } else {
-                // Fallback on earlier versions
+                taskDelegate = AVErrorDelegate(task: task)
             }
+            self.originalTask = originalTask
         case .stream(let originalTask, let task):
             taskDelegate = TaskDelegate(task: task)
             self.originalTask = originalTask

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -692,6 +692,8 @@ open class AVAssetDownloadRequest: Request {
         }
     }
 
+    /// A closure executed once the local file URL is established for the AVURLAsset.
+    public typealias AssetDestination = ( _ location: URL) -> ()
     
     /// The AVAsset that can be played be used with an AVPlayerItem, during download
     open var avAsset: AVURLAsset {

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -691,5 +691,24 @@ open class AVAssetDownloadRequest: Request {
             }
         }
     }
+
+    /// The progress of downloading the response data from the server for the request.
+    open var progress: Progress { return avAssetDownloadDelegate.progress }
+    
+    var avAssetDownloadDelegate: AVAssetDownloadTaskDelegate { return delegate as! AVAssetDownloadTaskDelegate }
+
+    // MARK: Progress
+    
+    /// Sets a closure to be called periodically during the lifecycle of the `Request` as data is read from the server.
+    ///
+    /// - parameter queue:   The dispatch queue to execute the closure on.
+    /// - parameter closure: The code to be executed periodically as data is read from the server.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    open func downloadProgress(queue: DispatchQueue = DispatchQueue.main, closure: @escaping ProgressHandler) -> Self {
+        avAssetDownloadDelegate.progressHandler = (closure, queue)
+        return self
+    }
 }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -692,6 +692,13 @@ open class AVAssetDownloadRequest: Request {
         }
     }
 
+    
+    /// The AVAsset that can be played be used with an AVPlayerItem, during download
+    open var avAsset: AVURLAsset {
+        let avAssetDownloadTask  = task as! AVAssetDownloadTask
+        return avAssetDownloadTask.urlAsset
+    }
+
     /// The progress of downloading the response data from the server for the request.
     open var progress: Progress { return avAssetDownloadDelegate.progress }
     

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -902,7 +902,10 @@ open class AVAssetDownloadSessionManager : SessionManager {
     ///                                       challenges. `nil` by default.
     ///
     /// - returns: The new `SessionManager` instance.
-    public init(backgroundIdentifier: String, delegate: AVDownloadSessionDelegate, serverTrustPolicyManager: ServerTrustPolicyManager?) {
+    public init(
+        backgroundIdentifier: String,
+        delegate: AVDownloadSessionDelegate = AVDownloadSessionDelegate(),
+        serverTrustPolicyManager: ServerTrustPolicyManager? = nil) {
         let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
         let session = AVAssetDownloadURLSession(configuration: configuration, assetDownloadDelegate: delegate, delegateQueue: nil)
         

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -891,22 +891,54 @@ open class SessionManager {
 open class AVAssetDownloadSessionManager : SessionManager {
     // MARK: - Properties
     
-    init(backgroundIdentifier: String, delegate: AVDownloadSessionDelegate, serverTrustPolicyManager: ServerTrustPolicyManager?) {
-        let configuration = URLSessionConfiguration.background(withIdentifier: "avBackground")
+    // MARK: - Lifecycle
+    
+    /// Creates an instance with the specified `backgroundIdentifier`, `delegate` and `serverTrustPolicyManager`.
+    ///
+    /// - parameter backgroundIdentifier:            A string that identifies the background session.
+    /// - parameter delegate:                 The delegate used when initializing the session. `SessionDelegate()` by
+    ///                                       default.
+    /// - parameter serverTrustPolicyManager: The server trust policy manager to use for evaluating all server trust
+    ///                                       challenges. `nil` by default.
+    ///
+    /// - returns: The new `SessionManager` instance.
+    public init(backgroundIdentifier: String, delegate: AVDownloadSessionDelegate, serverTrustPolicyManager: ServerTrustPolicyManager?) {
+        let configuration = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
         let session = AVAssetDownloadURLSession(configuration: configuration, assetDownloadDelegate: delegate, delegateQueue: nil)
         
         super.init(session: session, delegate: delegate, serverTrustPolicyManager: serverTrustPolicyManager)!
     }
     
+    // MARK: - Download AVAsset Request
+    
+    // MARK: AVURLAsset with title and artwork-data
+    
+    /// Creates a `AVAssetDownloadRequest` to retrieve offline AVAsset the specified `asset`, `title`, `data`, `options`.
+    ///
+    /// - parameter asset:       The AVURLAsset to be downloaded for offline viewing.
+    /// - parameter title:       The title of the download, used to identify the asset while downloading.
+    /// - parameter options:     The options, see AVAssetDownloadTask*Key.
+    ///
+    /// - returns: The created `AVAssetDownloadRequest`.
     @available(iOSApplicationExtension 10.0, *)
     @discardableResult
     open func downloadAVAsset(asset: AVURLAsset, title: String, data: Data?, options: [String: Any]?) -> AVAssetDownloadRequest {
         return downloadAVAsset(.assetTitleArtwork(asset, title, data, options))
     }
     
+    /// Creates a `AVAssetDownloadRequest` to retrieve offline AVAsset the specified `asset`, `destFileURL`, `options`.
+    ///
+    /// - parameter asset:       The AVURLAsset to be downloaded for offline viewing.
+    /// - parameter destFileURL: The fileURL of the destination where the asset will be saved.
+    /// - parameter options:     The options, see AVAssetDownloadTask*Key.
+    ///
+    /// - returns: The created `AVAssetDownloadRequest`.
+    @available(iOS, introduced: 9.0, deprecated: 10.0)
     open func downloadAVAsset(asset: AVURLAsset, destFileURL: URL, options: [String: Any]?) -> AVAssetDownloadRequest {
         return downloadAVAsset(.assetFileURL(asset, destFileURL, options))
     }
+    
+    // MARK: Private - Download AV Asset implementation
     
     private func downloadAVAsset(_ avDownloadable: AVAssetDownloadRequest.AVAssetDownloadable) -> AVAssetDownloadRequest {
         do {

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -23,6 +23,7 @@
 //
 
 import Foundation
+import AVFoundation
 
 /// Responsible for creating and managing `Request` objects, as well as their underlying `NSURLSession`.
 open class SessionManager {
@@ -884,4 +885,18 @@ open class SessionManager {
             }
         }
     }
+}
+
+@available(iOSApplicationExtension 9.0, *)
+open class AVAssetDownloadSessionManager : SessionManager {
+    // MARK: - Properties
+    
+    init(backgroundIdentifier: String, delegate: AVDownloadSessionDelegate, serverTrustPolicyManager: ServerTrustPolicyManager?) {
+        let configuration = URLSessionConfiguration.background(withIdentifier: "avBackground")
+        let session = AVAssetDownloadURLSession(configuration: configuration, assetDownloadDelegate: delegate, delegateQueue: nil)
+        
+        super.init(session: session, delegate: delegate, serverTrustPolicyManager: serverTrustPolicyManager)!
+    }
+    
+    
 }

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -922,8 +922,13 @@ open class AVAssetDownloadSessionManager : SessionManager {
     /// - returns: The created `AVAssetDownloadRequest`.
     @available(iOSApplicationExtension 10.0, *)
     @discardableResult
-    open func downloadAVAsset(asset: AVURLAsset, title: String, data: Data?, options: [String: Any]?) -> AVAssetDownloadRequest {
-        return downloadAVAsset(.assetTitleArtwork(asset, title, data, options))
+    open func downloadAVAsset(
+        asset: AVURLAsset,
+        title: String,
+        data: Data? = nil,
+        options: [String: Any]? = nil,
+        location: AVAssetDownloadRequest.AssetDestination? = nil) -> AVAssetDownloadRequest {
+        return downloadAVAsset(.assetTitleArtwork(asset, title, data, options), location: location)
     }
     
     /// Creates a `AVAssetDownloadRequest` to retrieve offline AVAsset the specified `asset`, `destFileURL`, `options`.
@@ -934,16 +939,24 @@ open class AVAssetDownloadSessionManager : SessionManager {
     ///
     /// - returns: The created `AVAssetDownloadRequest`.
     @available(iOS, introduced: 9.0, deprecated: 10.0)
-    open func downloadAVAsset(asset: AVURLAsset, destFileURL: URL, options: [String: Any]?) -> AVAssetDownloadRequest {
-        return downloadAVAsset(.assetFileURL(asset, destFileURL, options))
+    open func downloadAVAsset(
+        asset: AVURLAsset,
+        destFileURL: URL,
+        options: [String: Any]? = nil,
+        location: AVAssetDownloadRequest.AssetDestination? = nil) -> AVAssetDownloadRequest {
+        return downloadAVAsset(.assetFileURL(asset, destFileURL, options), location: location)
     }
     
     // MARK: Private - Download AV Asset implementation
     
-    private func downloadAVAsset(_ avDownloadable: AVAssetDownloadRequest.AVAssetDownloadable) -> AVAssetDownloadRequest {
+    private func downloadAVAsset(
+        _ avDownloadable: AVAssetDownloadRequest.AVAssetDownloadable,
+        location: AVAssetDownloadRequest.AssetDestination?) -> AVAssetDownloadRequest {
         do {
             let task = try avDownloadable.task(session: session, adapter: adapter, queue: queue)
             let request = AVAssetDownloadRequest(session: session, requestTask: .avAssetDownload(avDownloadable, task))
+            
+            request.avAssetDownloadDelegate.location = location
             
             delegate[task] = request
             

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -480,6 +480,8 @@ class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
     var progress: Progress
     var progressHandler: (closure: Request.ProgressHandler, queue: DispatchQueue)?
     
+    var location: AVAssetDownloadRequest.AssetDestination?
+    
     // MARK: Lifecycle
     override init(task: URLSessionTask?) {
         progress = Progress(totalUnitCount: 0)
@@ -500,7 +502,8 @@ class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
     open var avSessionDownloadDidResolve: ((URLSession, AVAssetDownloadTask, AVMediaSelection) -> Void)?
     
     func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didFinishDownloadingTo location: URL) {
-        avSessionDownloadTaskDidFinishLoadingTo?(session, assetDownloadTask, location)
+        
+        self.location?(location)
     }
     
     func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didLoad timeRange: CMTimeRange, totalTimeRangesLoaded loadedTimeRanges: [NSValue], timeRangeExpectedToLoad: CMTimeRange) {

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -23,6 +23,7 @@
 //
 
 import Foundation
+import AVFoundation
 
 /// The task delegate is responsible for handling all delegate callbacks for the underlying task as well as
 /// executing all operations attached to the serial operation queue upon task completion.
@@ -400,6 +401,64 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
             progress.totalUnitCount = expectedTotalBytes
             progress.completedUnitCount = fileOffset
         }
+    }
+}
+
+// MARK: -
+
+@available(iOSApplicationExtension 9.0, *)
+class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
+    
+    // MARK: Properties
+    
+    var avAssetDownloadTask: AVAssetDownloadTask { return task as! AVAssetDownloadTask }
+    
+    var progress: Progress
+    var progressHandler: (closure: Request.ProgressHandler, queue: DispatchQueue)?
+    
+    // MARK: Lifecycle
+    
+    init(avTask: AVAssetDownloadTask?) {
+        progress = Progress(totalUnitCount: 0)
+      //  guard let task
+        
+        super.init(task: avTask)
+    }
+    
+    override func reset() {
+        super.reset()
+        progress = Progress(totalUnitCount: 0)
+    }
+    
+    // MARK: AVAssetDownloadDelegate
+    
+    open var avSessionDownloadTaskDidFinishLoadingTo: ((URLSession, AVAssetDownloadTask, URL) -> Void)?
+    open var avSessionDownloadDidLoadRanges: ((URLSession, AVAssetDownloadTask, CMTimeRange, [NSValue], CMTimeRange) -> Void)?
+    open var avSessionDownloadDidResolve: ((URLSession, AVAssetDownloadTask, AVMediaSelection) -> Void)?
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didFinishDownloadingTo location: URL) {
+        avSessionDownloadTaskDidFinishLoadingTo?(session, assetDownloadTask, location)
+    }
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didLoad timeRange: CMTimeRange, totalTimeRangesLoaded loadedTimeRanges: [NSValue], timeRangeExpectedToLoad: CMTimeRange) {
+        if let avSessionDownloadDidLoadRanges = avSessionDownloadDidLoadRanges {
+            avSessionDownloadDidLoadRanges(session, assetDownloadTask, timeRange, loadedTimeRanges, timeRangeExpectedToLoad)
+        } else {
+            progress.totalUnitCount = Int64(timeRangeExpectedToLoad.duration.seconds)
+            
+            progress.completedUnitCount = Int64(loadedTimeRanges.reduce(0, { (result: Double, value: NSValue) -> Double in
+                let loadedTimeRange = value.timeRangeValue
+                return result + loadedTimeRange.duration.seconds
+            }))
+
+            if let progressHandler = progressHandler {
+                progressHandler.queue.async { progressHandler.closure(self.progress) }
+            }
+        }
+    }
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didResolve resolvedMediaSelection: AVMediaSelection) {
+        avSessionDownloadDidResolve?(session, assetDownloadTask, resolvedMediaSelection)
     }
 }
 

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -463,6 +463,21 @@ class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
 }
 
 // MARK: -
+/// The sole purpose of AVErrorDelegate is to return an error when used prior to iOS 9.
+class AVErrorDelegate : TaskDelegate {
+    override var error: Error? {
+        get {
+            enum AVErrorDelegateError: Error {
+                case AVDownloadNotAvailable
+            }
+            
+            return AVErrorDelegateError.AVDownloadNotAvailable
+        }
+        set {}
+    }
+}
+
+// MARK: -
 
 class UploadTaskDelegate: DataTaskDelegate {
 

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -406,79 +406,6 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
 
 // MARK: -
 
-@available(iOSApplicationExtension 9.0, *)
-class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
-    
-    // MARK: Properties
-    
-    var avAssetDownloadTask: AVAssetDownloadTask { return task as! AVAssetDownloadTask }
-    
-    var progress: Progress
-    var progressHandler: (closure: Request.ProgressHandler, queue: DispatchQueue)?
-    
-    // MARK: Lifecycle
-    
-    init(avTask: AVAssetDownloadTask?) {
-        progress = Progress(totalUnitCount: 0)
-      //  guard let task
-        
-        super.init(task: avTask)
-    }
-    
-    override func reset() {
-        super.reset()
-        progress = Progress(totalUnitCount: 0)
-    }
-    
-    // MARK: AVAssetDownloadDelegate
-    
-    open var avSessionDownloadTaskDidFinishLoadingTo: ((URLSession, AVAssetDownloadTask, URL) -> Void)?
-    open var avSessionDownloadDidLoadRanges: ((URLSession, AVAssetDownloadTask, CMTimeRange, [NSValue], CMTimeRange) -> Void)?
-    open var avSessionDownloadDidResolve: ((URLSession, AVAssetDownloadTask, AVMediaSelection) -> Void)?
-    
-    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didFinishDownloadingTo location: URL) {
-        avSessionDownloadTaskDidFinishLoadingTo?(session, assetDownloadTask, location)
-    }
-    
-    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didLoad timeRange: CMTimeRange, totalTimeRangesLoaded loadedTimeRanges: [NSValue], timeRangeExpectedToLoad: CMTimeRange) {
-        if let avSessionDownloadDidLoadRanges = avSessionDownloadDidLoadRanges {
-            avSessionDownloadDidLoadRanges(session, assetDownloadTask, timeRange, loadedTimeRanges, timeRangeExpectedToLoad)
-        } else {
-            progress.totalUnitCount = Int64(timeRangeExpectedToLoad.duration.seconds)
-            
-            progress.completedUnitCount = Int64(loadedTimeRanges.reduce(0, { (result: Double, value: NSValue) -> Double in
-                let loadedTimeRange = value.timeRangeValue
-                return result + loadedTimeRange.duration.seconds
-            }))
-
-            if let progressHandler = progressHandler {
-                progressHandler.queue.async { progressHandler.closure(self.progress) }
-            }
-        }
-    }
-    
-    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didResolve resolvedMediaSelection: AVMediaSelection) {
-        avSessionDownloadDidResolve?(session, assetDownloadTask, resolvedMediaSelection)
-    }
-}
-
-// MARK: -
-/// The sole purpose of AVErrorDelegate is to return an error when used prior to iOS 9.
-class AVErrorDelegate : TaskDelegate {
-    override var error: Error? {
-        get {
-            enum AVErrorDelegateError: Error {
-                case AVDownloadNotAvailable
-            }
-            
-            return AVErrorDelegateError.AVDownloadNotAvailable
-        }
-        set {}
-    }
-}
-
-// MARK: -
-
 class UploadTaskDelegate: DataTaskDelegate {
 
     // MARK: Properties
@@ -523,5 +450,77 @@ class UploadTaskDelegate: DataTaskDelegate {
                 uploadProgressHandler.queue.async { uploadProgressHandler.closure(self.uploadProgress) }
             }
         }
+    }
+}
+
+// MARK: -
+/// The sole purpose of AVErrorDelegate is to return an error when used prior to iOS 9.
+class AVErrorDelegate : TaskDelegate {
+    override var error: Error? {
+        get {
+            enum AVErrorDelegateError: Error {
+                case AVDownloadNotAvailable
+            }
+            
+            return AVErrorDelegateError.AVDownloadNotAvailable
+        }
+        set {}
+    }
+}
+
+// MARK: -
+
+@available(iOSApplicationExtension 9.0, *)
+class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
+    
+    // MARK: Properties
+    
+    var avAssetDownloadTask: AVAssetDownloadTask { return task as! AVAssetDownloadTask }
+    
+    var progress: Progress
+    var progressHandler: (closure: Request.ProgressHandler, queue: DispatchQueue)?
+    
+    // MARK: Lifecycle
+    override init(task: URLSessionTask?) {
+        progress = Progress(totalUnitCount: 0)
+        //  guard let task
+        
+        super.init(task: task)
+    }
+    
+    override func reset() {
+        super.reset()
+        progress = Progress(totalUnitCount: 0)
+    }
+    
+    // MARK: AVAssetDownloadDelegate
+    
+    open var avSessionDownloadTaskDidFinishLoadingTo: ((URLSession, AVAssetDownloadTask, URL) -> Void)?
+    open var avSessionDownloadDidLoadRanges: ((URLSession, AVAssetDownloadTask, CMTimeRange, [NSValue], CMTimeRange) -> Void)?
+    open var avSessionDownloadDidResolve: ((URLSession, AVAssetDownloadTask, AVMediaSelection) -> Void)?
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didFinishDownloadingTo location: URL) {
+        avSessionDownloadTaskDidFinishLoadingTo?(session, assetDownloadTask, location)
+    }
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didLoad timeRange: CMTimeRange, totalTimeRangesLoaded loadedTimeRanges: [NSValue], timeRangeExpectedToLoad: CMTimeRange) {
+        if let avSessionDownloadDidLoadRanges = avSessionDownloadDidLoadRanges {
+            avSessionDownloadDidLoadRanges(session, assetDownloadTask, timeRange, loadedTimeRanges, timeRangeExpectedToLoad)
+        } else {
+            progress.totalUnitCount = Int64(timeRangeExpectedToLoad.duration.seconds)
+            
+            progress.completedUnitCount = Int64(loadedTimeRanges.reduce(0, { (result: Double, value: NSValue) -> Double in
+                let loadedTimeRange = value.timeRangeValue
+                return result + loadedTimeRange.duration.seconds
+            }))
+            
+            if let progressHandler = progressHandler {
+                progressHandler.queue.async { progressHandler.closure(self.progress) }
+            }
+        }
+    }
+    
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didResolve resolvedMediaSelection: AVMediaSelection) {
+        avSessionDownloadDidResolve?(session, assetDownloadTask, resolvedMediaSelection)
     }
 }

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -482,6 +482,8 @@ class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
     
     var location: AVAssetDownloadRequest.AssetDestination?
     
+    var resolvedMediaSelection: AVMediaSelection?
+    
     // MARK: Lifecycle
     override init(task: URLSessionTask?) {
         progress = Progress(totalUnitCount: 0)
@@ -524,6 +526,6 @@ class AVAssetDownloadTaskDelegate: TaskDelegate, AVAssetDownloadDelegate {
     }
     
     func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask, didResolve resolvedMediaSelection: AVMediaSelection) {
-        avSessionDownloadDidResolve?(session, assetDownloadTask, resolvedMediaSelection)
+        self.resolvedMediaSelection = resolvedMediaSelection
     }
 }

--- a/Tests/AVAssetDownloadsTest.swift
+++ b/Tests/AVAssetDownloadsTest.swift
@@ -1,0 +1,71 @@
+//
+//  AVAssetDownloadTests.swift
+//  Alamofire
+//
+//  Created by Dan Morrow on 12/1/16.
+//  Copyright © 2016 Alamofire. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+import AVFoundation
+import XCTest
+
+class AVAssetDownloadTests: XCTestCase {
+    
+    var manager: AVAssetDownloadSessionManager!
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        manager = AVAssetDownloadSessionManager(backgroundIdentifier: "alamo-tests-background")
+    }
+    
+    override func tearDown() {
+        manager.session.finishTasksAndInvalidate()
+        
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+        
+    }
+    
+    func testExample() {
+        
+        let expectation = self.expectation(description: "response received")
+        
+        var response : AVAssetDownloadResponse?
+        
+        let asset = AVURLAsset(url: URL(string: "https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8")!)
+        manager.downloadAVAsset(asset: asset, title: "basic stream", data: nil, options: nil, location: { url in
+            
+            XCTAssertNotNil(url)
+            
+            print("the local file URL for the downloadable asset is \(url)")
+        }).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 20, handler: nil)
+        
+        XCTAssertNotNil(response?.avURLAsset)
+        XCTAssertNotNil(response?.resolvedMediaSelection)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNil(response?.error)
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
made modifications to Request, SessionDelegate and other classes to support downloading AVAssets through the AVAssetDownload* classes.

My first test of this is broken (unfortunately) and I don't know why. The failure occurs in `AVAssetDownloadRequest`, in it's `task` routine. To create a new `AVAssetDownloadTask`, the `session` instance has to be of type `AVAssetDownloadURLSession`. I have a subclass of `SessionManager` called `AVAssetDownloadSessionManager` which does appear to be creating a `AVAssetDownloadURLSession`. But later on the requests `task` routine, I have this statement:

```
guard let avSession = session as? AVAssetDownloadURLSession else { throw AVSessionError.NotAVAssetDownloadURLSession }
```

It always fails. I have no explanation for why an AVAssetDownloadURLSession gets created in one place, but when you ask it what it is later, it's not the right type. 